### PR TITLE
Add command line interface using clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 rand = "0.9.0"
 csv = { version = "1.3.1", optional = true }
+clap = { version = "4.5", features = ["derive"] }
 
 [features]
 default = ["force-ballots", "validate"]

--- a/src/data.rs
+++ b/src/data.rs
@@ -121,7 +121,7 @@ impl std::fmt::Display for Fraction {
 // over lists that have received 0 votes than the 'true ballot' approach; but
 // otherwise is identical to it
 #[cfg(not(feature = "force-ballots"))]
-pub fn ballotted<T>(mut vec: Vec<T>, limit: Count) -> impl Iterator<Item = T> {
+pub fn balloted<T>(mut vec: Vec<T>, limit: Count) -> impl Iterator<Item = T> {
     use rand::rng;
     use rand::seq::SliceRandom;
 
@@ -138,7 +138,7 @@ pub fn ballotted<T>(mut vec: Vec<T>, limit: Count) -> impl Iterator<Item = T> {
 }
 
 #[cfg(feature = "force-ballots")]
-pub fn ballotted<T>(vec: Vec<T>, _limit: Count) -> impl Iterator<Item = T> {
+pub fn balloted<T>(vec: Vec<T>, _limit: Count) -> impl Iterator<Item = T> {
     use rand::rng;
     use rand::seq::IteratorRandom;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::iter;
 
 /// This performs one step in an apportionment algorithm, allocating seats based on a
 /// "criterion" for how 'worthy' a certain party in the `seats` list is to receive the seats.
-/// It is a **requirement** that the `criterion` algorith will always rank a party that is
+/// It is a **requirement** that the `criterion` algorithm will always rank a party that is
 /// eligible for at least one more "eat" above a party that doesn't.
 /// The `criterion` can signal that a party isn't eligible for seats by returning `None`.
 pub fn allocate_single_step<Quality: Ord>(
@@ -30,7 +30,7 @@ pub fn allocate_single_step<Quality: Ord>(
         .filter_map(|(quality, seat)| (quality.as_ref() == Some(max_quality)).then_some(seat))
         .collect::<Vec<_>>();
 
-    for seat in ballotted(awarded, available_seats.count()) {
+    for seat in balloted(awarded, available_seats.count()) {
         seat.transfer(available_seats);
     }
 
@@ -66,7 +66,7 @@ pub fn absolute_majority_check(votes: &[Votes], seats: &mut [Seats], prev_seats:
             .filter_map(|(x, y)| (*x > y && *x != winner_seat).then_some(x))
             .collect::<Vec<_>>();
 
-        let loser_seat = ballotted(last_winners, 1).next().unwrap();
+        let loser_seat = balloted(last_winners, 1).next().unwrap();
         correction.transfer(loser_seat);
     }
 }
@@ -93,7 +93,7 @@ fn debug_results(mut things: impl Iterator<Item: std::fmt::Display>) {
 }
 
 /// Perform a seat apportionment based on the given method.
-/// It is a **requirement** that the `criterion` algorith will always rank a party that is
+/// It is a **requirement** that the `criterion` algorithm will always rank a party that is
 /// eligible for at least one more "eat" above a party that doesn't.
 pub fn allocate_seats<Quality: Ord>(
     votes: &[Votes],


### PR DESCRIPTION
Supports the following commands:
- `help` (generated by clap)
- `demo`
- `allocate` (e.g. `cargo run -- allocate 17 2,5,8,4,5 --national`)
- `validate` (e.g. `cargo run -- validate data/uitslag_TK*`) — only available with the `validate` feature (which is on by default)